### PR TITLE
Allow defining custom S3 endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ S3-brain can be configured with environment variables:
 - `HUBOT_S3_BRAIN_BUCKET` Bucket to store brain in
 - `HUBOT_S3_BRAIN_FILE_PATH` Optional path/file in bucket to store brain at
 - `HUBOT_S3_BRAIN_SAVE_INTERVAL` Optional auto-save interval in seconds
+- `HUBOT_S3_BRAIN_ENDPOINT` Alternative S3 API endpoint
 
 It's highly recommended to use an IAM account explicitly for this s3-brain.
 A sample S3 policy for a bucket named Hubot-Bucket would be:

--- a/scripts/brain.coffee
+++ b/scripts/brain.coffee
@@ -7,6 +7,7 @@
 #   HUBOT_S3_BRAIN_BUCKET             - Bucket to store brain in
 #   HUBOT_S3_BRAIN_FILE_PATH          - [Optional] Path/File in bucket to store brain at
 #   HUBOT_S3_BRAIN_SAVE_INTERVAL      - [Optional] auto-save interval in seconds
+#   HUBOT_S3_BRAIN_ENDPOINT           - [Optional] Alternative S3 API endpoint
 #
 # Commands:
 #
@@ -68,6 +69,7 @@ module.exports = (robot) ->
   file_path         = process.env.HUBOT_S3_BRAIN_FILE_PATH || "brain-dump.json"
   # default to 30 minutes (in seconds)
   save_interval     = process.env.HUBOT_S3_BRAIN_SAVE_INTERVAL || 30 * 60
+  s3_endpoint       = process.env.HUBOT_S3_BRAIN_ENDPOINT
 
   if !key && !secret && !bucket
     throw new Error('S3 brain requires HUBOT_S3_BRAIN_ACCESS_KEY_ID, ' +
@@ -77,7 +79,14 @@ module.exports = (robot) ->
   if isNaN(save_interval)
     throw new Error('HUBOT_S3_BRAIN_SAVE_INTERVAL must be an integer')
 
-  s3 = new AWS.S3({params: {Bucket: bucket, Key: file_path}})
+  args = {
+    params: {Bucket: bucket, Key: file_path},
+  }
+  if s3_endpoint
+    args.endpoint = new AWS.Endpoint(s3_endpoint)
+    args.s3ForcePathStyle = true
+
+  s3 = new AWS.S3(args)
 
   store_brain = (brain_data, callback) ->
     if !loaded


### PR DESCRIPTION
This can be useful for:
1. people which actually store the brain in unofficial, [S3-compatible storages](http://www.s3-client.com/s3-storage-providers.html)
2. local environment during development, e.g. w/ [Fake S3](https://github.com/jubos/fake-s3)
