### PR TITLE
Add optional to HUBOT_S3_BRAIN_ENDPOINT description

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ S3-brain can be configured with environment variables:
 - `HUBOT_S3_BRAIN_BUCKET` Bucket to store brain in
 - `HUBOT_S3_BRAIN_FILE_PATH` Optional path/file in bucket to store brain at
 - `HUBOT_S3_BRAIN_SAVE_INTERVAL` Optional auto-save interval in seconds
-- `HUBOT_S3_BRAIN_ENDPOINT` Alternative S3 API endpoint
+- `HUBOT_S3_BRAIN_ENDPOINT` Optional alternative S3 API endpoint
 
 It's highly recommended to use an IAM account explicitly for this s3-brain.
 A sample S3 policy for a bucket named Hubot-Bucket would be:


### PR DESCRIPTION
At the first glance, README sounded like `HUBOT_S3_BRAIN_ENDPOINT` is required, because it does not say `Optional` while other optional vars have the word on their descriptions.

Like the comment below, it would be more readable if we add Optional 
https://github.com/dylanmei/hubot-s3-brain/blob/d371b146a1b929ac2962fddc57eb4cd7e51a3815/scripts/brain.coffee#L5-L10