### PR TITLE
Make AWS access key and secret optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Then add hubot-rules to your external-scripts.json:
 
 S3-brain can be configured with environment variables:
 
-- `HUBOT_S3_BRAIN_ACCESS_KEY_ID` AWS Access Key ID with S3 permissions
-- `HUBOT_S3_BRAIN_SECRET_ACCESS_KEY` AWS Secret Access Key for ID
+- `HUBOT_S3_BRAIN_ACCESS_KEY_ID` Optional AWS Access Key ID with S3 permissions
+- `HUBOT_S3_BRAIN_SECRET_ACCESS_KEY` Optional AWS Secret Access Key for ID
 - `HUBOT_S3_BRAIN_BUCKET` Bucket to store brain in
 - `HUBOT_S3_BRAIN_FILE_PATH` Optional path/file in bucket to store brain at
 - `HUBOT_S3_BRAIN_SAVE_INTERVAL` Optional auto-save interval in seconds

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-s3-brain",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Stores the brain in Amazon S3",
   "author": "Dylan Meissner",
   "licenses": [],

--- a/scripts/brain.coffee
+++ b/scripts/brain.coffee
@@ -2,9 +2,9 @@
 #   Stores the brain in Amazon S3.
 #
 # Configuration:
-#   HUBOT_S3_BRAIN_ACCESS_KEY_ID      - AWS Access Key ID with S3 permissions
-#   HUBOT_S3_BRAIN_SECRET_ACCESS_KEY  - AWS Secret Access Key for ID
 #   HUBOT_S3_BRAIN_BUCKET             - Bucket to store brain in
+#   HUBOT_S3_BRAIN_ACCESS_KEY_ID      - [Optional] AWS Access Key ID with S3 permissions
+#   HUBOT_S3_BRAIN_SECRET_ACCESS_KEY  - [Optional] AWS Secret Access Key for ID
 #   HUBOT_S3_BRAIN_FILE_PATH          - [Optional] Path/File in bucket to store brain at
 #   HUBOT_S3_BRAIN_SAVE_INTERVAL      - [Optional] auto-save interval in seconds
 #   HUBOT_S3_BRAIN_ENDPOINT           - [Optional] Alternative S3 API endpoint
@@ -71,9 +71,8 @@ module.exports = (robot) ->
   save_interval     = process.env.HUBOT_S3_BRAIN_SAVE_INTERVAL || 30 * 60
   s3_endpoint       = process.env.HUBOT_S3_BRAIN_ENDPOINT
 
-  if !key && !secret && !bucket
-    throw new Error('S3 brain requires HUBOT_S3_BRAIN_ACCESS_KEY_ID, ' +
-      'HUBOT_S3_BRAIN_SECRET_ACCESS_KEY and HUBOT_S3_BRAIN_BUCKET configured')
+  if !bucket
+    throw new Error('S3 brain requires HUBOT_S3_BRAIN_BUCKET to be configured')
 
   save_interval = parseInt(save_interval)
   if isNaN(save_interval)


### PR DESCRIPTION
This allows hubot to work when running in ECS, EC2, etc. with an assumed
role which in turn has access to the bucket.

Bumps package to 0.2.0

Closes #1